### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://dev.azure.com/JDAVIS79/e2992344-29b8-434c-92c7-f59c570c30a3/c848460e-7d0b-4dd5-869c-d36107d1f312/_apis/work/boardbadge/5aef4483-6561-4a7f-8198-b6aa570ce8e9)](https://dev.azure.com/JDAVIS79/e2992344-29b8-434c-92c7-f59c570c30a3/_boards/board/t/c848460e-7d0b-4dd5-869c-d36107d1f312/Microsoft.RequirementCategory)
 # cloud
 projects


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/JDAVIS79/e2992344-29b8-434c-92c7-f59c570c30a3/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.